### PR TITLE
記事データを格納する場合の配列が空の場合にエラーが出ないよう修正

### DIFF
--- a/next/src/pages/api/fetchData.tsx
+++ b/next/src/pages/api/fetchData.tsx
@@ -19,7 +19,6 @@ export const fetchProfile = async (
 // 記事一覧情報の取得のAPI
 export const fetchArticleList = async () => {
   const res = await axios.get("http://localhost:9090");
-
   return res.data;
 };
 

--- a/next/src/templates/ArticleList.tsx
+++ b/next/src/templates/ArticleList.tsx
@@ -17,9 +17,12 @@ const ArticleList: React.FC = () => {
   return (
     <div>
       <div className="mx-72 grid grid-cols-2 gap-2 bg-orange-100">
-        {data.map((articleData: any) => {
-          return <ArticleComp key={articleData.id} articleData={articleData} />;
-        })}
+        {data &&
+          data.map((articleData: any) => {
+            return (
+              <ArticleComp key={articleData.id} articleData={articleData} />
+            );
+          })}
       </div>
     </div>
   );


### PR DESCRIPTION
記事データを格納する場合の配列が空の場合にエラーが出ないよう修正しました。