### PR TITLE
ログイン認証判定

### DIFF
--- a/next/src/components/organisms/HeaderComp.tsx
+++ b/next/src/components/organisms/HeaderComp.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import Router from "next/router";
 import React, { useState, ChangeEvent } from "react";
-import { removeUserId } from "../../lib/cookie/handleCookie";
+import getCookie, { removeUserId } from "../../lib/cookie/handleCookie";
+import toast, { Toaster } from "react-hot-toast";
 import { SearchOutlined, UserOutlined, DownOutlined } from "@ant-design/icons";
 import { Menu, Dropdown, Drawer, Space } from "antd";
 
@@ -27,10 +28,34 @@ const HeaderComp: React.FC<search> = ({
   const menu = (
     <Menu>
       <Menu.Item key="0">
-        <a href={"/profile"}>プロフィール</a>
+        <button
+          onClick={() => {
+            const guestId = getCookie();
+            if (guestId == null) {
+              toast.error(`ログインして下さい`);
+              Router.push("/");
+            } else if (guestId != null) {
+              Router.push("/profile");
+            }
+          }}
+        >
+          プロフィール
+        </button>
       </Menu.Item>
       <Menu.Item key="1">
-        <a href={"/articleSaved"}>下書き記事</a>
+        <button
+          onClick={() => {
+            const guestId = getCookie();
+            if (guestId == null) {
+              toast.error(`ログインして下さい`);
+              Router.push("/");
+            } else if (guestId != null) {
+              Router.push("/articleSaved");
+            }
+          }}
+        >
+          下書き保存
+        </button>
       </Menu.Item>
       <Menu.Item key="2">
         <button
@@ -45,8 +70,29 @@ const HeaderComp: React.FC<search> = ({
     </Menu>
   );
 
+  const goToAddArticle = () => {
+    const guestId = getCookie();
+    if (guestId == null) {
+      toast.error(`ログインして下さい`);
+      Router.push("/");
+    } else if (guestId != null) {
+      Router.push("/articleAdd");
+    }
+  };
+
+  const goToQiitaList = () => {
+    const guestId = getCookie();
+    if (guestId == null) {
+      toast.error(`ログインして下さい`);
+      Router.push("/");
+    } else if (guestId != null) {
+      Router.push("/qiitaList");
+    }
+  };
+
   return (
     <React.Fragment>
+      <Toaster />
       <div className="flex gap-1 justify-between border">
         <button
           onClick={reloadArticles}
@@ -100,17 +146,18 @@ const HeaderComp: React.FC<search> = ({
             </a>
           </Dropdown>
 
-          {/* 画面遷移のためLink */}
-          <Link href={"/articleAdd"}>
-            <a className="px-4 py-3 m-4 text-white hover:text-white font-semibold bg-sky-400 hover:bg-sky-500 active:bg-sky-500 focus:outline-none focus:ring focus:ring-sky-300 rounded-md shadow-xl">
-              Add News
-            </a>
-          </Link>
-          <Link href={"/qiitaList"}>
-            <a className="px-4 py-3 mr-5 my-4 text-white hover:text-white font-semibold bg-sky-400 hover:bg-sky-500 active:bg-sky-500 focus:outline-none focus:ring focus:ring-sky-300 rounded-md shadow-xl">
-              Qiita
-            </a>
-          </Link>
+          <button
+            onClick={goToAddArticle}
+            className="px-4 py-3 m-4 text-white hover:text-white font-semibold bg-sky-400 hover:bg-sky-500 active:bg-sky-500 focus:outline-none focus:ring focus:ring-sky-300 rounded-md shadow-xl"
+          >
+            Add News
+          </button>
+          <button
+            onClick={goToQiitaList}
+            className="px-4 py-3 mr-5 my-4 text-white hover:text-white font-semibold bg-sky-400 hover:bg-sky-500 active:bg-sky-500 focus:outline-none focus:ring focus:ring-sky-300 rounded-md shadow-xl"
+          >
+            Qiita
+          </button>
         </div>
       </div>
     </React.Fragment>

--- a/next/src/components/organisms/HeaderComp.tsx
+++ b/next/src/components/organisms/HeaderComp.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Router from "next/router";
 import React, { useState, ChangeEvent } from "react";
+import { removeUserId } from "../../lib/cookie/handleCookie";
 import { SearchOutlined, UserOutlined, DownOutlined } from "@ant-design/icons";
 import { Menu, Dropdown, Drawer, Space } from "antd";
 
@@ -32,13 +33,14 @@ const HeaderComp: React.FC<search> = ({
         <a href={"/articleSaved"}>下書き記事</a>
       </Menu.Item>
       <Menu.Item key="2">
-        <a href={"/registerUser"}>会員登録</a>
-      </Menu.Item>
-      <Menu.Item key="3">
-        <a href={"/loginUser"}>ログイン</a>
-      </Menu.Item>
-      <Menu.Item key="4">
-        <a href={"/loginUser"}>ログアウト</a>
+        <button
+          onClick={() => {
+            removeUserId();
+            Router.push("/");
+          }}
+        >
+          ログアウト
+        </button>
       </Menu.Item>
     </Menu>
   );

--- a/next/src/components/organisms/LoginUser.tsx
+++ b/next/src/components/organisms/LoginUser.tsx
@@ -1,14 +1,19 @@
 import Router from "next/router";
 import { ChangeEvent, useState } from "react";
 import toast, { Toaster } from "react-hot-toast";
-import getCookie, { settingUserId } from "../lib/cookie/handleCookie";
-import { loginUser } from "../lib/api/fetchData";
+import getCookie, { settingUserId } from "../../lib/cookie/handleCookie";
+import { loginUser } from "../../lib/api/fetchData";
+
+export type register = {
+  isRegistered: boolean;
+  setIsRegistered: React.Dispatch<React.SetStateAction<boolean>>;
+};
 
 const goToReissue = () => {
   Router.push("/reissuePassword");
 };
 
-const LoginUser: React.FC = () => {
+const LoginUser: React.FC<register> = ({ isRegistered, setIsRegistered }) => {
   // メールアドレス
   const [mailAddress, setMailAddress] = useState<string>("");
   // テキストボックス入力時に入力内容をStateに設定
@@ -42,25 +47,34 @@ const LoginUser: React.FC = () => {
   return (
     <div className="pb-28 h-screen w-screen flex flex-col gap-2 justify-center items-center">
       <Toaster />
-      <div className="mr-56 text-4xl font-semibold text-sky-500">Login</div>
+      <div className="w-80 flex justify-between">
+        <div className="text-4xl font-semibold text-sky-500">Quish</div>
+      </div>
       <input
         type="text"
         onChange={onChangeMailAddress}
         placeholder="E-mail（rakusのメールアドレス）"
-        className="m-4 px-6 py-4 w-80 bg-white rounded-sm border-2"
+        className="m-4 px-6 py-4 w-80 bg-white rounded border-2 focus:outline-none focus:border-sky-500"
       />
       <input
         type="password"
         onChange={onChangePassword}
         placeholder="Password（英数字8文字以上）"
-        className="px-6 py-4 w-80 bg-white rounded-sm border-2"
+        className="px-6 py-4 w-80 bg-white rounded border-2 focus:outline-none focus:border-sky-500"
       />
-      <button
-        onClick={goToReissue}
-        className="ml-40 text-sm text-gray-500 no-underline hover:underline"
-      >
-        パスワードを忘れた場合
-      </button>
+
+      <div className="flex justify-between w-80">
+        <button className="hover:underline" onClick={goToReissue}>
+          パスワードを忘れた場合
+        </button>
+        <button
+          className="hover:underline"
+          onClick={() => setIsRegistered(!isRegistered)}
+        >
+          会員登録はこちら
+        </button>
+      </div>
+
       <button
         onClick={() => {
           Login();

--- a/next/src/components/organisms/RegisterUser.tsx
+++ b/next/src/components/organisms/RegisterUser.tsx
@@ -1,9 +1,17 @@
 import Router from "next/router";
 import { ChangeEvent, useState } from "react";
-import { registerUser } from "../lib/api/addData";
-import { useRegisterChecker } from "../hooks/useRegisterChecker";
+import { registerUser } from "../../lib/api/addData";
+import { useRegisterChecker } from "../../hooks/useRegisterChecker";
 
-const RegisterUser: React.FC = () => {
+export type register = {
+  isRegistered: boolean;
+  setIsRegistered: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const RegisterUser: React.FC<register> = ({
+  isRegistered,
+  setIsRegistered,
+}) => {
   // ユーザーネーム
   const [userName, setUserName] = useState<string>("");
   // テキストボックス入力時に入力内容をStateに設定
@@ -63,13 +71,14 @@ const RegisterUser: React.FC = () => {
       password,
       confirmPassword
     );
-
-    Router.push("/loginUser");
+    setIsRegistered(!isRegistered);
   };
 
   return (
-    <div className="pb-16 h-screen w-screen flex flex-col gap-10 justify-center items-center">
-      <div className="mr-48 text-4xl font-semibold text-sky-500">Register</div>
+    <div className="pb-16 h-screen w-screen flex flex-col gap-6 justify-center items-center">
+      <div className="w-80 flex justify-between">
+        <div className="text-4xl font-semibold text-sky-500">Quish</div>
+      </div>
 
       <div className="flex flex-col">
         <span className="text-red-500">{errorOfUserName}</span>
@@ -79,13 +88,13 @@ const RegisterUser: React.FC = () => {
             type="text"
             onChange={onChangeUserName}
             placeholder="Username"
-            className="px-6 py-4 w-40 bg-white rounded-sm border-2"
+            className="px-6 py-4 w-40 bg-white rounded border-2 focus:outline-none focus:border-sky-400"
           />
 
           <select
             value={engineerType}
             onChange={onChangeSelectJob}
-            className="ml-4 px-4 py-4 w-36 bg-white rounded-sm border-2"
+            className="ml-4 px-4 py-4 w-36 bg-white rounded border-2 focus:outline-none focus:border-sky-400"
           >
             <option>Please select</option>
             <option value="FR">FR</option>
@@ -102,7 +111,7 @@ const RegisterUser: React.FC = () => {
           type="text"
           onChange={onChangeMailAddress}
           placeholder="E-mail（rakusのメールアドレス）"
-          className="px-6 py-4 w-80 bg-white rounded-sm border-2"
+          className="px-6 py-4 w-80 bg-white rounded border-2 focus:outline-none focus:border-sky-500"
         />
       </div>
 
@@ -112,7 +121,7 @@ const RegisterUser: React.FC = () => {
           type="password"
           onChange={onChangePassword}
           placeholder="Password（英数字8文字以上）"
-          className="px-6 py-4 w-80 bg-white rounded-sm border-2"
+          className="px-6 py-4 w-80 bg-white rounded border-2 focus:outline-none focus:border-sky-500"
         />
       </div>
 
@@ -122,16 +131,23 @@ const RegisterUser: React.FC = () => {
           type="password"
           onChange={onChangeConfirmPassword}
           placeholder="Confirm Password"
-          className="px-6 py-4 w-80 bg-white rounded-sm border-2"
+          className="px-6 py-4 w-80 bg-white rounded border-2 focus:outline-none focus:border-sky-500"
         />
       </div>
-
-      <button
-        onClick={() => Register()}
-        className="px-6 py-4 w-80 bg-sky-400 text-white text-xl text-center rounded-md hover:bg-sky-600"
-      >
-        会員登録
-      </button>
+      <div className="flex flex-col -mt-4">
+        <button
+          className="mb-2 self-end hover:underline"
+          onClick={() => setIsRegistered(!isRegistered)}
+        >
+          ログインはこちら
+        </button>
+        <button
+          onClick={() => Register()}
+          className="px-6 py-4 w-80 bg-sky-400 text-white text-xl text-center rounded hover:bg-sky-600"
+        >
+          会員登録
+        </button>
+      </div>
     </div>
   );
 };

--- a/next/src/lib/cookie/handleCookie.tsx
+++ b/next/src/lib/cookie/handleCookie.tsx
@@ -3,7 +3,6 @@ import { parseCookies, setCookie, destroyCookie } from "nookies";
 // cookieからデータを取得
 const getCookie = (ctx?: any) => {
   const cookie = parseCookies(ctx);
-
   return cookie.guestId;
 };
 export default getCookie;
@@ -18,9 +17,6 @@ export const settingUserId = (userId: number) => {
     maxAge: 24 * 60 * 60,
     path: "/",
   });
-
-  // クッキーに設定したUserIdを削除する処理
-  // destroyCookie(null, "userId");
 };
 
 // 記事投稿者のIdをCookieから取得する処理
@@ -35,6 +31,12 @@ export const setArticleUserId = (userId: number) => {
     // 60秒 * 60 秒 * 24 で一日間保存
     maxAge: 24 * 60 * 60,
   });
+};
+
+// クッキーに設定したUserIdを削除する処理
+export const removeUserId = () => {
+  destroyCookie(null, "guestId");
+  console.log("Cookieの値を削除します");
 };
 
 export const removeArticleUserId = () => {

--- a/next/src/pages/index.tsx
+++ b/next/src/pages/index.tsx
@@ -8,7 +8,6 @@ const Home: React.FC = () => {
   // 記事詳細のみCookieにarticleUserIdを保持するため削除
   useEffect(() => {
     const guestId = getCookie();
-    console.log(guestId);
     if (guestId == null) {
       setIsLogin(false);
       console.log("ログアウトします");
@@ -16,7 +15,6 @@ const Home: React.FC = () => {
       setIsLogin(true);
       console.log("記事一覧を表示します");
     }
-    console.log(isLogin);
     removeArticleUserId();
   });
   return <>{isLogin ? <ArticleList /> : <Auth />}</>;

--- a/next/src/pages/index.tsx
+++ b/next/src/pages/index.tsx
@@ -1,17 +1,25 @@
-import { useEffect } from "react";
-import { removeArticleUserId } from "../lib/cookie/handleCookie";
+import { useState, useEffect } from "react";
+import Auth from "../templates/Auth";
+import getCookie, { removeArticleUserId } from "../lib/cookie/handleCookie";
 import { ArticleList } from "../templates";
 
 const Home: React.FC = () => {
+  const [isLogin, setIsLogin] = useState(false);
   // 記事詳細のみCookieにarticleUserIdを保持するため削除
   useEffect(() => {
+    const guestId = getCookie();
+    console.log(guestId);
+    if (guestId == null) {
+      setIsLogin(false);
+      console.log("ログアウトします");
+    } else if (guestId != null) {
+      setIsLogin(true);
+      console.log("記事一覧を表示します");
+    }
+    console.log(isLogin);
     removeArticleUserId();
   });
-  return (
-    <div>
-      <ArticleList />
-    </div>
-  );
+  return <>{isLogin ? <ArticleList /> : <Auth />}</>;
 };
 
 export default Home;

--- a/next/src/pages/reissuePassword.tsx
+++ b/next/src/pages/reissuePassword.tsx
@@ -39,7 +39,7 @@ const ReissuePassword: React.FC = () => {
         type="text"
         onChange={onChangeMailAddress}
         placeholder="E-mail（rakusのメールアドレス)"
-        className="m-4 px-6 py-4 w-80 bg-white rounded-sm"
+        className="m-4 px-6 py-4 w-80 bg-white rounded border-2 focus:outline-none focus:border-sky-500"
       />
       <div>
         ※パスワードを忘れた方は、メールアドレスを入力し新しいパスワードを再設定して下さい。
@@ -49,7 +49,7 @@ const ReissuePassword: React.FC = () => {
         onClick={() => {
           reissue();
         }}
-        className="px-6 py-4 w-80 bg-orange-400 text-white text-xl text-center rounded-md hover:bg-amber-600"
+        className="px-6 py-4 w-80 bg-sky-400 text-white text-xl text-center rounded hover:bg-sky-600"
       >
         送信
       </button>

--- a/next/src/pages/resetPassword.tsx
+++ b/next/src/pages/resetPassword.tsx
@@ -28,14 +28,14 @@ const ResetPassword: React.FC = () => {
       toast.error(`新しいパスワードの設定に失敗しました。`);
     } else {
       toast.success(`新しいパスワードの設定が完了しました。`);
-      Router.push("/loginUser");
+      Router.push("/");
     }
   };
 
   return (
     <div className="h-screen w-screen flex flex-col gap-2 justify-center items-center">
       <Toaster />
-      <div className="m-4 mr-20 text-4xl font-semibold text-orange-500">
+      <div className="m-4 mr-20 text-4xl font-semibold text-sky-500">
         パスワード再設定
       </div>
       <div>登録中のメールアドレス：{router.query.email}</div>
@@ -44,14 +44,14 @@ const ResetPassword: React.FC = () => {
         onChange={onChangeNewPassword}
         placeholder="新しいパスワード(英数字8桁以上)
         "
-        className="px-6 py-4 w-80 bg-white rounded-sm"
+        className="px-6 py-4 w-80 bg-white rounded border-2 focus:outline-none focus:border-sky-500"
       />
 
       <button
         onClick={() => {
           reset();
         }}
-        className="px-6 py-4 w-80 bg-orange-400 text-white text-xl text-center rounded-md hover:bg-amber-600"
+        className="px-6 py-4 w-80 bg-sky-400 text-white text-xl text-center rounded-md hover:bg-sky-600"
       >
         送信
       </button>

--- a/next/src/templates/Auth.tsx
+++ b/next/src/templates/Auth.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+import RegisterUser from "../components/organisms/RegisterUser";
+import LoginUser from "../components/organisms/LoginUser";
+
+const Auth: React.FC = () => {
+  const [isRegistered, setIsRegistered] = useState(false);
+  return (
+    <div>
+      {isRegistered ? (
+        <RegisterUser
+          isRegistered={isRegistered}
+          setIsRegistered={setIsRegistered}
+        />
+      ) : (
+        <LoginUser
+          isRegistered={isRegistered}
+          setIsRegistered={setIsRegistered}
+        />
+      )}
+    </div>
+  );
+};
+
+export default Auth;


### PR DESCRIPTION
ログイン認証判定機能を実装しました。
・記事一覧表示時にログインがされていない場合(Cookieに値が保存されていない場合)はログイン画面を表示する。
・記事一覧を表示した状態で、Cookieの値をディベロッパーツールで削除した後、
　プロフィール画面や記事投稿画面に遷移しようとするとログインを要求する仕様に変更しました。